### PR TITLE
avoid the error when the /usr/local/man/man8/ not exist.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ install:
 	#mkdir for tsar
 	mkdir -p /usr/local/tsar/modules
 	mkdir -p /etc/tsar
+	mkdir -p /usr/local/man/man8/
 	#copy tsar shared so
 	cp modules/*.so /usr/local/tsar/modules
 	#copy bin file


### PR DESCRIPTION
在使用#make install安装程序的时候,如果目录/usr/local/man/man8/不存在,就出现了如下错误:
# copy man file

cp conf/tsar.8 /usr/local/man/man8/
cp: cannot create regular file `/usr/local/man/man8/': Is a directory
make: **\* [install] Error 1
