### PR TITLE
Ignore wrong data read on Raspbian

### DIFF
--- a/modules/mod_rpi.c
+++ b/modules/mod_rpi.c
@@ -21,7 +21,7 @@
  * Structure for rpi infomation.
  */
 struct stats_rpi {
-	unsigned int cpu_temp;
+	int cpu_temp;
 };
 
 #define STATS_TEST_SIZE (sizeof(struct stats_rpi))
@@ -44,6 +44,10 @@ static void read_rpi_stats(struct module *mod, char *parameter)
 	int cpu_temp;
 
 	fscanf(fp, "%d", &cpu_temp);
+    
+    if (cpu_temp == 85*1000 || cpu_temp < 1) {
+        return;
+    }
 
 	st_rpi.cpu_temp = cpu_temp;
 


### PR DESCRIPTION
Sometimes the cpu temp is read as 85000 or negative value on Raspbian, it's a known bug which doesn't happen on Arch Linux.
