### PR TITLE
find error in config.c

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -93,17 +93,19 @@ void parse_string(char *var)
 void parse_add_string(char *var)
 {
     char    *token = strtok(NULL, W_SPACE);
+    /*
     if (var == NULL){
         if(token)
             strncpy(var, token, strlen(token));
     }else{
+    */
         if(token){
             strcat(token, ",");
             strncat(token, var, strlen(var));
         }
         if(token)
             strncpy(var, token, strlen(token));
-    }
+    //}
 }
 
 void set_debug_level()
@@ -185,7 +187,8 @@ void parse_config_file(const char *file_name)
     memset(&statis, '\0', sizeof(statis));
     conf.server_port = (int *)malloc(sizeof(int));
     conf.cycle_time = (int *)malloc(sizeof(int));
-    conf.debug_level = LOG_ERR;
+    //conf.debug_level = LOG_ERR;
+    conf.debug_level = LOG_INFO;
     conf.print_detail = FALSE;
     while (fgets(config_input_line, LEN_1024, fp)) {
         if ((token = strchr(config_input_line, '\n')))


### PR DESCRIPTION
... < log_err,所以没有关键字的错误信息是无法打印出来的;在parse_add_string函数里,conf.output_db_mod的值是一个地址是不可能为NULL的,所以此处var == NULL是无效的,具体见代码
