### PR TITLE
add 3 more metrics of /proc/net/snmp into tcp_module

### DIFF
--- a/modules/mod_tcp.c
+++ b/modules/mod_tcp.c
@@ -12,6 +12,7 @@ struct stats_tcp {
     unsigned long long OutSegs;
     unsigned long long AttemptFails;
     unsigned long long EstabResets;
+    unsigned long long CurrEstab;
     unsigned long long RetransSegs;
     unsigned long long InErrs;
     unsigned long long OutRsts;
@@ -38,11 +39,12 @@ read_tcp_stats(struct module *mod)
         if (!strncmp(line, "Tcp:", 4)) {
             if (sw) {
                 sscanf(line + 4, "%*u %*u %*u %*d %llu %llu "
-                        "%llu %llu %*u %llu %llu %llu %llu %llu",
+                        "%llu %llu %llu %llu %llu %llu %llu %llu",
                         &st_tcp.ActiveOpens,
                         &st_tcp.PassiveOpens,
                         &st_tcp.AttemptFails,
                         &st_tcp.EstabResets,
+                        &st_tcp.CurrEstab,
                         &st_tcp.InSegs,
                         &st_tcp.OutSegs,
                         &st_tcp.RetransSegs,
@@ -58,12 +60,16 @@ read_tcp_stats(struct module *mod)
 
     fclose(fp);
 
-    int pos = sprintf(buf, "%lld,%lld,%lld,%lld,%lld",
+    int pos = sprintf(buf, "%lld,%lld,%lld,%lld,%lld,%lld,%lld,%lld",
             st_tcp.ActiveOpens,
             st_tcp.PassiveOpens,
             st_tcp.InSegs,
             st_tcp.OutSegs,
+            st_tcp.EstabResets,
+            st_tcp.AttemptFails,
+            st_tcp.CurrEstab,
             st_tcp.RetransSegs);
+
     buf[pos] = '\0';
     set_mod_record(mod, buf);
 }
@@ -73,16 +79,19 @@ set_tcp_record(struct module *mod, double st_array[],
     U_64 pre_array[], U_64 cur_array[], int inter)
 {
     int i;
-    for (i = 0; i < 4; i++) {
+    for (i = 0; i < 6; i++) {
         if (cur_array[i] >= pre_array[i]) {
             st_array[i] = (cur_array[i] - pre_array[i]) * 1.0 / inter;
         }
     }
-    if ((cur_array[4] >= pre_array[4]) && (cur_array[3] > pre_array[3])) {
-        st_array[4] = (cur_array[4]- pre_array[4]) * 100.0 / (cur_array[3]- pre_array[3]);
+    /* 6 is for st_tcp.CurrEstab */
+    st_array[6] = cur_array[6];
+    /* as for st_tcp.RetransSegs,  we calculate the retransfer radio.  Retrans/outSegs */
+    if ((cur_array[7] >= pre_array[7]) && (cur_array[3] > pre_array[3])) {
+        st_array[7] = (cur_array[7]- pre_array[7]) * 100.0 / (cur_array[3]- pre_array[3]);
     }
-    if (st_array[4] > 100.0) {
-        st_array[4] = 100.0;
+    if (st_array[7] > 100.0) {
+        st_array[7] = 100.0;
     }
 }
 
@@ -91,11 +100,14 @@ static struct mod_info tcp_info[] = {
     {"pasive", DETAIL_BIT,  0,  STATS_SUB_INTER},
     {"  iseg", DETAIL_BIT,  0,  STATS_SUB_INTER},
     {"outseg", DETAIL_BIT,  0,  STATS_SUB_INTER},
+    {"EstReset", DETAIL_BIT,  0,  STATS_SUB_INTER},
+    {"AtmpFail", DETAIL_BIT,  0,  STATS_SUB_INTER},
+    {"CurrEstab", DETAIL_BIT,  0,  STATS_SUB_INTER},
     {"retran", SUMMARY_BIT,  0,  STATS_SUB_INTER}
 };
 
 void
 mod_register(struct module *mod)
 {
-    register_mod_fileds(mod, "--tcp", tcp_usage, tcp_info, 5, read_tcp_stats, set_tcp_record);
+    register_mod_fileds(mod, "--tcp", tcp_usage, tcp_info, 8, read_tcp_stats, set_tcp_record);
 }


### PR DESCRIPTION
添加了CurrEstab， 并显示了AtmpFail，CurrEstab，EstabResets 3个指标。 相信在有些时候可能会用到。
