### PR TITLE
fix a bug when tsar.conf comment line have space ahead.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,3 +43,7 @@ uninstall:
 	rm -f /usr/bin/tsardevel
 	#backup configure file
 	mv /etc/tsar/tsar.conf /etc/tsar/tsar.conf.rpmsave
+
+tags:
+	ctags -R
+	cscope -Rbq

--- a/modules/mod_proc.c
+++ b/modules/mod_proc.c
@@ -58,26 +58,27 @@ read_proc_stats(struct module *mod, char *parameter)
         if (nb >= 16) {
             return;
         }
-        p=strtok(NULL, " ");
+        p = strtok(NULL, " ");
     }
     /* get all pid's info */
-    while (--nb >=0) {
+    while (--nb >= 0) {
         unsigned long long data;
         /* read values from /proc/pid/stat */
         sprintf(filename, PID_STAT, pid[nb]);
         if ((fp = fopen(filename, "r")) == NULL) {
             return;
-	}
+        }
         unsigned long long cpudata[4];
         if (fgets(line, 256, fp) == NULL) {
             return;
         }
+
         p = strstr(line, ")");
-	if (sscanf(p, "%*s %*c %*d %*d %*d %*d %*d %*u %*u %*u %*u %*u %llu %llu %llu %llu",
+        if (sscanf(p, "%*s %*c %*d %*d %*d %*d %*d %*u %*u %*u %*u %*u %llu %llu %llu %llu",
                     &cpudata[0], &cpudata[1], &cpudata[2], &cpudata[3]) == EOF) {
             fclose(fp);
             return;
-	}
+        }
         st_proc.user_cpu += cpudata[0];
         st_proc.user_cpu += cpudata[2];
         st_proc.sys_cpu += cpudata[1];

--- a/src/config.c
+++ b/src/config.c
@@ -159,6 +159,10 @@ parse_line(char *buff)
         /* ignore empty lines */
         (void) 0;
 
+    } else if (token[0] == '#') {
+        /* ignore comment lines */
+        (void) 0;
+
     } else if (strstr(token, "mod_")) {
         parse_mod(token);
 

--- a/src/tsar.c
+++ b/src/tsar.c
@@ -173,9 +173,8 @@ main_init(int argc, char **argv)
 
     if (RUN_NULL == conf.running_mode) {
         conf.running_mode = RUN_PRINT;
-    }
 
-    if (conf.running_mode == RUN_CHECK_NEW) {
+    } else if (conf.running_mode == RUN_CHECK_NEW) {
         conf.print_interval = 60;
         conf.print_tail = 0;
         conf.print_nline_interval = conf.print_interval;


### PR DESCRIPTION
[Sat Mar 22 00:09:41 2014] config.c:239 parse_config_file: unknown keyword in '     ####[output_db]' at file /etc/tsar/tsar.conf
