### PR TITLE
Add support for OpenVZ interfaces

### DIFF
--- a/modules/mod_traffic.c
+++ b/modules/mod_traffic.c
@@ -39,7 +39,7 @@ read_traffic_stats(struct module *mod)
     memset(&total_st, 0, sizeof(cur_st));
 
     while (fgets(line, LEN_4096, fp) != NULL) {
-        if (strstr(line, "eth") || strstr(line, "em")) {
+        if (strstr(line, "eth") || strstr(line, "em") || strstr(line, "venet")) {
             memset(&cur_st, 0, sizeof(cur_st));
             p = strchr(line, ':');
             sscanf(p + 1, "%llu %llu %*u %*u %*u %*u %*u %*u "


### PR DESCRIPTION
The default name of a network interface in an OpenVZ container is venet
rather than the most commonly eth, e.g., venet0:0
