### PR TITLE
不再限制网口名称

### DIFF
--- a/modules/mod_traffic.c
+++ b/modules/mod_traffic.c
@@ -43,7 +43,7 @@ read_traffic_stats(struct module *mod)
     memset(&total_st, 0, sizeof(cur_st));
 
     while (fgets(line, LEN_4096, fp) != NULL) {
-        if (strstr(line, "eth") || strstr(line, "em") || strstr(line, "venet")) {
+        if (strstr(line, ":") && !strstr(line, "lo:")) {
             memset(&cur_st, 0, sizeof(cur_st));
             p = strchr(line, ':');
             sscanf(p + 1, "%llu %llu %llu %llu %*u %*u %*u %*u "


### PR DESCRIPTION
以匹配冒号来代替具体网口名称，借此可以不用再限制任何网口名称