### PR TITLE
access return bug

### DIFF
--- a/src/tsar.c
+++ b/src/tsar.c
@@ -197,7 +197,7 @@ main_init(int argc, char **argv)
     }
 
     strcpy(conf.config_file, DEFAULT_CONF_FILE_PATH);
-    if (access(conf.config_file, F_OK)) {
+    if (access(conf.config_file, F_OK) != 0) {
         do_debug(LOG_FATAL, "main_init: can't find tsar.conf");
     }
 }


### PR DESCRIPTION
linux access return:
> On success (all requested permissions granted, or mode is F_OK and the file exists), zero is returned.
> On error (at least one bit in mode asked for a permission that is denied, or mode is F_OK and the  file   does not exist, or some other error occurred), -1 is returned,and errno is set appropriately.


refer： [http://man7.org/linux/man-pages/man2/access.2.html](url)