### PR TITLE
add network interface `en` for mod_traffic according systemd new nami…

### DIFF
--- a/modules/mod_traffic.c
+++ b/modules/mod_traffic.c
@@ -43,7 +43,7 @@ read_traffic_stats(struct module *mod)
     memset(&total_st, 0, sizeof(cur_st));
 
     while (fgets(line, LEN_4096, fp) != NULL) {
-        if (strstr(line, "eth") || strstr(line, "em") || strstr(line, "venet")) {
+        if (strstr(line, "eth") || strstr(line, "em") || strstr(line, "en") ||strstr(line, "venet")) {
             memset(&cur_st, 0, sizeof(cur_st));
             p = strchr(line, ':');
             sscanf(p + 1, "%llu %llu %llu %llu %*u %*u %*u %*u "


### PR DESCRIPTION
systemd对网卡有新的命名法， #63 也描述了这个问题，systemd的文档https://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames/  对此也做出了说明，按照该文档所述，新的命名规则为：https://github.com/systemd/systemd/blob/master/src/udev/udev-builtin-net_id.c#L20 ，Ethernet的前缀一定是en，所以能不能加个en的匹配，对使用systemd系统支持。