### PR TITLE
fix `/sbin/pidof` not found error

### DIFF
--- a/modules/mod_proc.c
+++ b/modules/mod_proc.c
@@ -36,7 +36,7 @@ read_proc_stats(struct module *mod, char *parameter)
     if (strlen(parameter) > 20) {
         return;
     }
-    char cmd[32] = "/sbin/pidof ";
+    char cmd[32] = "pidof ";
     strncat(cmd, parameter, sizeof(cmd) - strlen(cmd) -1);
     char  spid[256];
     fp = popen(cmd, "r");


### PR DESCRIPTION
`pidof` may not be located in `/sbin`, we will fail to collect information in this case. But we could expect `pidof` are always been accessible.