### PR TITLE
Formmat document in Markdown format

### DIFF
--- a/info.md
+++ b/info.md
@@ -1,6 +1,6 @@
-##系统模块
-###cpu
-####字段含义
+## 系统模块
+### cpu
+#### 字段含义
 * user:  表示CPU执行用户进程的时间,通常期望用户空间CPU越高越好.
 * sys:   表示CPU在内核运行时间,系统CPU占用率高,表明系统某部分存在瓶颈.通常值越低越好.
 * wait:  CPU在等待I/O操作完成所花费的时间.系统部应该花费大量时间来等待I/O操作,否则就说明I/O存在瓶颈.
@@ -11,30 +11,32 @@
 * steal: 被强制等待（involuntary wait）虚拟CPU的时间,此时hypervisor在为另一个虚拟处理器服务
 * ncpu:  CPU的总个数
 
-####采集方式
+#### 采集方式
 CPU的占用率计算,都是根据/proc/stat计数器文件而来,stat文件的内容基本格式是:
 
     cpu  67793686 1353560 66172807 4167536491 2705057 0 195975 609768
     cpu0 10529517 944309 11652564 835725059 2150687 0 74605 196726
     cpu1 14380773 127146 13908869 832565666 150815 0 31780 108418
 
-cpu是总的信息,cpu0,cpu1等是各个具体cpu的信息,共有8个值,单位是ticks,分别是
-> User time, 67793686
-Nice time, 1353560
-System time, 66172807
-Idle time, 4167536491
-Waiting time, 2705057
-Hard Irq time, 0
-SoftIRQ time, 195975
-Steal time, 609768
+cpu是总的信息,cpu0,cpu1等是各个具体cpu的信息,共有8个值,单位是ticks,分别是：
+- User time, 67793686
+- Nice time, 1353560
+- System time, 66172807
+- Idle time, 4167536491
+- Waiting time, 2705057
+- Hard Irq time, 0
+- SoftIRQ time, 195975
+- Steal time, 609768
 
 `CPU总时间=user+system+nice+idle+iowait+irq+softirq+Stl`
-各个状态的占用=状态的cpu时间％CPU总时间＊100%
-比较特殊的是CPU总使用率的计算(util),目前的算法是:
-`util = 1 - idle - iowait - steal`
 
-###mem
-####字段含义
+各个状态的占用=状态的cpu时间/CPU总时间＊100%
+
+比较特殊的是CPU总使用率的计算(util),目前的算法是:
+`util = 1 - idle - iowait - steal` 。
+
+### mem
+#### 字段含义
 * free:   空闲的物理内存的大小
 * used:   已经使用的内存大小
 * buff:   buff使用的内存大小,buffer is something that has yet to be "written" to disk.
@@ -42,7 +44,7 @@ Steal time, 609768
 * total:  系统总的内存大小
 * util:   内存使用率
 
-####采集方法
+#### 采集方法
 内存的计数器在/proc/meminfo,里面有一些关键项
 
         MemTotal:      7680000 kB
@@ -53,40 +55,45 @@ Steal time, 609768
 含义就不解释了,主要介绍一下内存使用率的计算算法:
 `util = (total - free - buff - cache) / total * 100%`
 
-###load
-####字段含义
+### load
+#### 字段含义
 * load1: 一分钟的系统平均负载
 * load5: 五分钟的系统平均负载
 * load15:十五分钟的系统平均负载
 * runq:  在采样时刻,运行队列的任务的数目,与/proc/stat的procs_running表示相同意思
 * plit:  在采样时刻,系统中活跃的任务的个数（不包括运行已经结束的任务）
 
-####采集方法
-/proc/loadavg文件中保存的有负载相关的数据
+#### 采集方法
+/proc/loadavg文件中保存的有负载相关的数据：
+
 `0.00 0.01 0.00 1/271 23741`
+
 分别是1分钟负载,五分钟负载,十五分钟负载,运行进程／总进程 最大的pid
+
 只需要采集前五个数据既可得到所有信息
+
 注意:只有当系统负载除cpu核数>1的时候,系统负载较高
 
-###traffic
-####字段含义
+### traffic
+#### 字段含义
 * bytin:   入口流量byte/s
 * bytout:  出口流量byte/s
 * pktin:   入口pkt/s
 * pktout:  出口pkt/s
 
-####采集方法
+#### 采集方法
 流量的计数器信息来自:/proc/net/dev
 
         face |bytes    packets errs drop fifo frame compressed multicast|bytes    packets errs drop fifo colls carrier compressed
         lo:1291647853895 811582000    0    0    0     0          0         0 1291647853895 811582000    0    0    0     0       0          0
         eth0:853633725380 1122575617    0    0    0     0          0         0 1254282827126 808083790    0    0    0     0       0          0
 
-字段的含义第一行已经标示出来,每一行代表一个网卡,tsar主要采集的是出口和入口的bytes／packets
-注意tsar只对以eth和em开头的网卡数据进行了采集,像lo这种网卡直接就忽略掉了,流量的单位是byte
+字段的含义第一行已经标示出来,每一行代表一个网卡,tsar主要采集的是出口和入口的bytes／packets。
 
-###tcp
-####字段含义
+注意tsar只对以eth和em开头的网卡数据进行了采集,像lo这种网卡直接就忽略掉了,流量的单位是byte。
+
+### tcp
+#### 字段含义
 * active:主动打开的tcp连接数目
 * pasive:被动打开的tcp连接数目
 * iseg:  收到的tcp报文数目
@@ -96,32 +103,33 @@ Steal time, 609768
 * CurrEs:当前状态为ESTABLISHED的tcp连接数
 * retran:系统的重传率
 
-####采集方法
+#### 采集方法
 tcp的相关计数器文件是:/proc/net/snmp
 
         Tcp: RtoAlgorithm RtoMin RtoMax MaxConn ActiveOpens PassiveOpens AttemptFails EstabResets CurrEstab InSegs OutSegs RetransSegs InErrs OutRsts
         Tcp: 1 200 120000 -1 31702170 14416937 935062 772446 16 1846056224 1426620266 448823 0 5387732
 
 我们主要关注其中的ActiveOpens/PassiveOpens/AttemptFails/EstabResets/CurrEstab/InSegs/OutSegs/RetransSegs
+
 主要关注一下重传率的计算方式:
 `retran = (RetransSegs－last RetransSegs) ／ (OutSegs－last OutSegs) * 100%`
 
-###udp
-####字段含义
+### udp
+#### 字段含义
 * idgm:  收到的udp报文数目
 * odgm:  发送的udp报文数目
 * noport:udp协议层接收到目的地址或目的端口不存在的数据包
 * idmerr:udp层接收到的无效数据包的个数
 
 
-####采集方法
+#### 采集方法
 UDP的数据来源文件和TCP一样,也是在/proc/net/snmp
 
         Udp: InDatagrams NoPorts InErrors OutDatagrams
         Udp: 31609577 10708119 0 159885874
 
-###io
-####字段含义
+### io
+#### 字段含义
 * rrqms: The number of read requests merged per second that were issued to the device.
 * wrqms: The number of write requests merged per second that were issued to the device.
 * %rrqm: The percentage of read requests merged together before being sent to the device.
@@ -140,7 +148,7 @@ UDP的数据来源文件和TCP一样,也是在/proc/net/snmp
 * svctm: The average service time (in milliseconds) for I/O requests that were issued to the device.
 * util:  Percentage of CPU time during which I/O requests were issued to the device (bandwidth utilization for the device).Device saturation occurs when this value is close to 100%.
 
-####采集方法
+#### 采集方法
 IO的计数器文件是:/proc/diskstats,比如:
 
         202    0 xvda 12645385 1235409 416827071 59607552 193111576 258112651 3679534806 657719704 0 37341324 717325100
@@ -185,11 +193,11 @@ IO的计数器文件是:/proc/diskstats,比如:
     /*st_array分别代表tsar显示的每一个值*/
 
 注意:
-> 扇区一般都是512字节,因此有的地方除以2了
-> ws是指真正落到io设备上的写次数, wrqpms是指系统调用合并的写次数, 它们之间的大小关系没有可比性,因为不知道多少请求能够被合并,比如发起了100个read系统调用,每个读4K,假如这100个都是连续的读,由于硬盘通常允许最大的request为256KB,那么block层会把这100个读请求合并成2个request,一个256KB,另一个144KB,rrqpm/s为100,因为100个request都发生了合并,不管它最后合并成几个；r/s为2,因为最后的request数为2
+> 1. 扇区一般都是512字节,因此有的地方除以2了
+> 1. ws是指真正落到io设备上的写次数, wrqpms是指系统调用合并的写次数, 它们之间的大小关系没有可比性,因为不知道多少请求能够被合并,比如发起了100个read系统调用,每个读4K,假如这100个都是连续的读,由于硬盘通常允许最大的request为256KB,那么block层会把这100个读请求合并成2个request,一个256KB,另一个144KB,rrqpm/s为100,因为100个request都发生了合并,不管它最后合并成几个；r/s为2,因为最后的request数为2
 
-###partition
-####字段含义
+### partition
+#### 字段含义
 * bfree: 分区空闲的字节
 * bused: 分区使用中的字节
 * btotl: 分区总的大小
@@ -198,7 +206,7 @@ IO的计数器文件是:/proc/diskstats,比如:
 * itotl: 文件结点总数
 * iutil: 文件结点使用率
 
-####采集方法
+#### 采集方法
 首先通过/etc/mtab获取到分区信息,然后通过statfs访问该分区的信息,查询文件系统相关信息,包含:
 
         struct statfs {
@@ -216,12 +224,12 @@ IO的计数器文件是:/proc/diskstats,比如:
 
 然后就可以计算出tsar需要的信息,分区的字节数＝块数＊块大小＝f_blocks * f_bsize
 
-###pcsw
-####字段含义
+### pcsw
+#### 字段含义
 * cswch: 进程切换次数
 * proc:   新建的进程数
 
-####采集方法
+#### 采集方法
 计数器在/proc/stat:
 
         ctxt 19873315174
@@ -229,13 +237,16 @@ IO的计数器文件是:/proc/diskstats,比如:
 
 分别代表进程切换次数,以及进程数
 
-###tcpx
-####字段含义
+### tcpx
+#### 字段含义
 recvq sendq est twait fwait1 fwait2 lisq lising lisove cnest ndrop edrop rdrop pdrop kdrop
+
 分别代表
+
 tcprecvq tcpsendq tcpest tcptimewait tcpfinwait1 tcpfinwait2 tcplistenq tcplistenincq tcplistenover tcpnconnest tcpnconndrop tcpembdrop tcprexmitdrop tcppersistdrop tcpkadrop
-####采集方法
+#### 采集方法
 计数器来自:/proc/net/netstat /proc/net/snmp
+
 里面用到的数据有:
 
         TcpExt: SyncookiesSent SyncookiesRecv SyncookiesFailed EmbryonicRsts PruneCalled RcvPruned OfoPruned OutOfWindowIcmps LockDroppedIcmps ArpFilter TW TWRecycled TWKilled PAWSPassive PAWSActive PAWSEstab DelayedACKs DelayedACKLocked DelayedACKLost ListenOverflows ListenDrops TCPPrequeued TCPDirectCopyFromBacklog TCPDirectCopyFromPrequeue TCPPrequeueDropped TCPHPHits TCPHPHitsToUser TCPPureAcks TCPHPAcks TCPRenoRecovery TCPSackRecovery TCPSACKReneging TCPFACKReorder TCPSACKReorder TCPRenoReorder TCPTSReorder TCPFullUndo TCPPartialUndo TCPDSACKUndo TCPLossUndo TCPLoss TCPLostRetransmit TCPRenoFailures TCPSackFailures TCPLossFailures TCPFastRetrans TCPForwardRetrans TCPSlowStartRetrans TCPTimeouts TCPRenoRecoveryFail TCPSackRecoveryFail TCPSchedulerFailed TCPRcvCollapsed TCPDSACKOldSent TCPDSACKOfoSent TCPDSACKRecv TCPDSACKOfoRecv TCPAbortOnSyn TCPAbortOnData TCPAbortOnClose TCPAbortOnMemory TCPAbortOnTimeout TCPAbortOnLinger TCPAbortFailed TCPMemoryPressures
@@ -243,21 +254,21 @@ tcprecvq tcpsendq tcpest tcptimewait tcpfinwait1 tcpfinwait2 tcplistenq tcpliste
 
 具体字段找到并且获取即可
 
-###percpu ncpu
-####字段含义
+### percpu ncpu
+#### 字段含义
 字段含义等同cpu模块,只不过能够支持采集具体的每一个cpu的信息
-####采集方法
+#### 采集方法
 等同于cpu模块
 
-###pernic
-####字段含义
+### pernic
+#### 字段含义
 字段含义等同traffic模块,只不过能够支持采集具体的每一个网卡的信息
-####采集方法
+#### 采集方法
 等同于traffic模块
 
-##应用模块
-###proc
-####字段含义
+## 应用模块
+### proc
+#### 字段含义
 * user: 某个进程用户态cpu消耗
 * sys:  某个进程系统态cpu消耗
 * total:某个进程总的cpu消耗
@@ -266,7 +277,7 @@ tcprecvq tcpsendq tcpest tcptimewait tcpfinwait1 tcpfinwait2 tcplistenq tcpliste
 * read: 进程io读字节
 * write:进程的io写字节
 
-####采集方法
+### #采集方法
 计数器文件
 > /proc/pid/stat:获取进程的cpu信息
 > /proc/pid/status:获取进程的mem信息
@@ -274,8 +285,8 @@ tcprecvq tcpsendq tcpest tcptimewait tcpfinwait1 tcpfinwait2 tcplistenq tcpliste
 
 注意,需要将采集的进程名称配置在/etc/tsar/tsar.conf总的mod_proc on procname,这样就会找到procname的pid,并进行数据采集
 
-###nginx
-####字段含义
+### nginx
+#### 字段含义
 * accept:总共接收的新连接数目
 * handle:总共处理的连接数目
 * reqs:总共产生请求数目
@@ -290,7 +301,7 @@ tcprecvq tcpsendq tcpest tcptimewait tcpfinwait1 tcpfinwait2 tcplistenq tcpliste
 * sslhst:平均ssl握手时间ms
 
 
-####采集方法
+#### 采集方法
 通过nginx的采集模块配置,访问特定地址,具体参见:https://github.com/taobao/tsar-mod_nginx
 
         location = /nginx_status {
@@ -306,11 +317,11 @@ curl 127.0.0.1:80/nginx_status  -H 'Host: status.taobao.com'
          24 24 7 0
         Reading: 0 Writing: 1 Waiting: 0
         SSL: 0 SPDY: 0
-（注：对于上述返回数据中的server accepts handled requests request_time，当前是通过“ 24 24 7 0”数据行首的空格作为前导
-现tsar在本模块中同时支持“Server accepts: 24 handled: 24 requests: 7 request_time 0”格式返回该数据行。今后将升级tengine改用此方式。）
+（注：对于上述返回数据中的server accepts handled requests request_time，当前是通过“ 24 24 7 0”数据行首的空格作为前导。现tsar在本模块中同时支持“Server accepts: 24 handled: 24 requests: 7 request_time 0”格式返回该数据行。今后将升级tengine改用此方式。）
 
 需要确保nginx配置该location,并且能够访问`curl http://localhost/nginx_status`得到上面的数据  
 如果nginx的端口不是80,则需要在配置文件中指定端口,配置文件是/etc/tsar/tsar.conf,修改mod_nginx on为mod_nginx on 8080 。
+
 不同端口的nginx数据以不同item的形式展现，在对各item进行合并的时候（-m），除rt以及sslhst依然为平均值之外，其他的所有值都为所有端口的值的总和
 
 类似的有nginx_code, nginx_domain模块,相应的配置是:
@@ -355,12 +366,14 @@ curl 127.0.0.1:80/nginx_status  -H 'Host: status.taobao.com'
 * detail_other 非以上13种status code的请求总数
 
 如果domain数量太多,或者端口不是80,需要进行专门的配置,配置文件内容如下:
-port=8080 #指定nginx的端口
-top=10 #指定最多采集的域名个数，按照请求总个数排列
-domain=a.com b.com #指定特定需要采集的域名列表,分隔符为空格,逗号,或者制表符
+
+        port=8080 #指定nginx的端口
+        top=10 #指定最多采集的域名个数，按照请求总个数排列
+        domain=a.com b.com #指定特定需要采集的域名列表,分隔符为空格,逗号,或者制表符
+
 在/etc/tsar/tsar.conf中指定配置文件的路径:mod_nginx_domain on /tmp/my.conf
 
-####nginx_domain_traffic
+#### nginx_domain_traffic
 nginx配置是:
 
         req_status_zone server "$host" 20M;
@@ -393,7 +406,7 @@ nginx配置是:
 * 4XXout:  输出的4XX应答字节数byte/s
 * 5XXout:  输出的5XX应答字节数byte/s
 
-####nginx_ups
+#### nginx_ups
 用于输出nginx upstream想关信息
 nginx配置是:
 
@@ -424,8 +437,8 @@ nginx配置是:
 * fbt:   tengine首字节时间
 * ufbt:  后端应答首字节时间
 
-###nginx_live
-####字段含义
+### nginx_live
+#### 字段含义
 * online:当前总共在线数
 * olhstr:历史总共在线数
 * olvary:历史在线数增长量（待商榷，不显示）
@@ -438,14 +451,14 @@ nginx配置是:
 * dropfr:丢帧
 
 
-####采集方法
+#### 采集方法
 请确保如下方式能得到数据：
 curl -x 127.0.0.1:7001 http://status.taobao.com/rtmp_reqstat
 请求到的数据是:
 rtmp://pagefault/alicdn/diaoliang123,fm_time:574 drop_frame:0 online:1 online_history:2 down_flow:166096189 up_flow:166096188 internal:0 edge:2
 
-###squid
-####字段含义
+### squid
+#### 字段含义
 * qps:   每秒请求数
 * rt:    访问平均相应时间
 * r_hit: 请求命中率
@@ -471,11 +484,11 @@ rtmp://pagefault/alicdn/diaoliang123,fm_time:574 drop_frame:0 online:1 online_hi
 * hit:   haproxy开启cache时的命中率
 * rt:    平均响应时间ms
 
-####采集方法
+#### 采集方法
 haproxy经过了patch,能够在多进程模式下进行统计信息的汇总,然后通过haproxy的本地访问其状态页面admin分析得到
 
-###lvs
-####字段含义
+### lvs
+#### 字段含义
 * stat:   lvs状态,1正常
 * conns: 总的连接数
 * pktin: 收到的包数
@@ -492,28 +505,32 @@ haproxy经过了patch,能够在多进程模式下进行统计信息的汇总,然
 * templ: 会话保持(模板) session 的数量
 
 
-####采集方法
+#### 采集方法
 内核版 lvs: 访问lvs的统计文件:/proc/net/ip_vs_stats, /proc/net/ip_vs_conn_stats
 netframe lvs: 访问 lvs 的命令行工具: slb_admin -ln --total --dump, appctl -cas
 
-###apache
+### apache
 参见:https://github.com/kongjian/tsar-apache
-###tcprt
+### tcprt
 私有应用,略
-###swift
+### swift
 私有应用,略
-###cgcpu/cgmem/cgblkio
+### cgcpu/cgmem/cgblkio
 私有应用,略
-###trafficserver
+### trafficserver
 待补充
-###tmd
+### tmd
 私有应用,略
 
-###lua
-####采集方法
+### lua
+#### 采集方法
 在/etc/tsar/tsar.conf中：
-mod_lua on {lua_file_name}
-启用lua模块，将从绝对路径调用{lua_file_name}这个lua脚本文件
-mod_lua 依赖luajit-5.1
+
+        mod_lua on {lua_file_name}
+
+启用lua模块，将从绝对路径调用{lua_file_name}这个lua脚本文件。
+
+mod_lua 依赖luajit-5.1。
+
 目前为仅有一个tsar模块支持lua，通过修改lua脚本文件来实现不同的数据采集。目前支持11个字段供lua操作
-具体实现样例见lua_modules/nginx_mem.lua，该脚本实现采集本机上所有nginx进程分配的内存总数
+具体实现样例见lua_modules/nginx_mem.lua，该脚本实现采集本机上所有nginx进程分配的内存总数。


### PR DESCRIPTION
tsar是一个好工具，但`info.md`文件的markdown格式存在一些问题，导致在Github上查看时，存在造成段落黏连，无标题等问题。

本PR格式化了info.md文件，以便开发者可以更方便阅读tsar的帮助信息。