### PR TITLE
Fix faults in incremental builds

### DIFF
--- a/modules/Makefile
+++ b/modules/Makefile
@@ -1,4 +1,4 @@
-CFLAGS = -Wall -fPIC --shared -g -O2 -Wno-strict-aliasing
+CFLAGS = -MD -Wall -fPIC --shared -g -O2 -Wno-strict-aliasing
 CC = gcc
 INCLUDE_DIR = ../include
 LINK = $(CC) -I$(INCLUDE_DIR) -I../src/obj/include $(CFLAGS)
@@ -24,4 +24,7 @@ $(OBJS): %.so: %.c
 	$(LINK) $< -o $@
 clean:
 	rm -f *.so;
+	rm -f *.d;
 	rm -rf *.dSYM;
+
+-include $(OBJS:.so=.d)

--- a/src/Makefile
+++ b/src/Makefile
@@ -9,7 +9,7 @@ LUAJIT = $(notdir $(patsubst %.tar.gz,%,$(wildcard deps/LuaJIT*.tar.gz)))
 ODIR = obj
 DEPS = $(ODIR)/lib/libluajit-5.1.a
 
-CFLAGS = -g -O2 -Wall -I../include -I$(ODIR)/include
+CFLAGS = -MD -g -O2 -Wall -I../include -I$(ODIR)/include
 LDFLAGS += -L$(ODIR)/lib -lluajit-5.1 -lm -ldl -rdynamic
 
 all: $(BIN)
@@ -35,4 +35,7 @@ $(ODIR):
 	@mkdir -p $@
 
 clean:
-	rm -rf *.o $(BIN) $(ODIR);
+	rm -rf *.o *.d $(BIN) $(ODIR);
+
+OBJS = *.o
+-include $(OBJS:.o=.d)


### PR DESCRIPTION
Hello

This pull request fixes faults in the build script of this project.
Specifically, it adds missing Make dependencies so that the targets of the project are re-generated correctly whenever there are updates to any of the dependent source files.

In this way, the project is incrementally built and we no longer sacrifice time in clean builds (i.e., builds after a make clean).

Note that this fix follows the best practices for tracking dependencies automatically (through `gcc -MD`)

For more details, see here.
https://www.gnu.org/software/make/manual/html_node/Automatic-Prerequisites.html