### PR TITLE
modify rpm/tsar-build.sh

### DIFF
--- a/rpm/tsar-build.sh
+++ b/rpm/tsar-build.sh
@@ -39,8 +39,7 @@ building_tag
 
 echo "/etc/redhat-release:"
 cat /etc/redhat-release
-distroverpkg=$(awk -F= '$1=="distroverpkg"{print $2}' /etc/yum.conf)
-releasever=$(rpm -q $distroverpkg|grep -Po "(?<=$distroverpkg-)[0-9]+")
+releasever=$(cut -d: -f5 /etc/system-release-cpe)
 if [[ -n "$releasever" ]]
 then
         release="$git_revision".el$releasever

--- a/rpm/tsar-build.sh
+++ b/rpm/tsar-build.sh
@@ -39,21 +39,13 @@ building_tag
 
 echo "/etc/redhat-release:"
 cat /etc/redhat-release
-
-if [ `cat /etc/redhat-release|cut -d " " -f 7|cut -d "." -f 1` = 4 ]
+distroverpkg=$(awk -F= '$1=="distroverpkg"{print $2}' /etc/yum.conf)
+releasever=$(rpm -q $distroverpkg|grep -Po "(?<=$distroverpkg-)[0-9]+")
+if [[ -n "$releasever" ]]
 then
-        release="$git_revision".el4
-elif [ `cat /etc/redhat-release|cut -d " " -f 7|cut -d "." -f 1` = 5 ]
-then
-        release="$git_revision".el5
-elif [ `cat /etc/redhat-release|cut -d " " -f 7|cut -d "." -f 1` = 6 ]
-then
-        release="$git_revision".el6
-elif [ `cat /etc/redhat-release|cut -d " " -f 7|cut -d "." -f 1` = 7 ]
-then
-        release="$git_revision".el7
+        release="$git_revision".el$releasever
 else
-        release="$git_revision".el5
+        release="$git_revision".el7
 fi
 
 RPM_MACROS=$HOME/.rpmmacros


### PR DESCRIPTION
Fix the problem that centos 7 can not build rpm and modify the default value to el7 and Unified centos 6/7/8 version acquisition method